### PR TITLE
A quick fix inspired by twbs #22272

### DIFF
--- a/src/components/collapse-native.js
+++ b/src/components/collapse-native.js
@@ -73,7 +73,7 @@ export default function Collapse(element,options) {
 
   // public methods
   self.toggle = e => {
-    e && e.preventDefault();
+    if (e && e.target.tagName === 'A') {e.preventDefault();}
     if (!hasClass(collapse,'show')) { self.show(); } 
     else { self.hide(); }
   }


### PR DESCRIPTION
The use of "preventDefault()" in all cases made impossible for an input that toggled a collapse via data api to receive the click event. As a result, all checkbox toggling a collapse through this method were unable to change state, and remained unchecked (or checked depending on their initial state) on click. This fix is similar to the solution twbs uses as of today, it only "preventDefault()" for "a" tags which may change the URL on click .